### PR TITLE
Obj exports polygons

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,10 +7,23 @@ set(BUILD_SHARED_LIBS OFF)
 cmake_policy(SET CMP0077 NEW) # set() overrides option()
 
 #--------------------------------
-# Debug Options
+# Options
 #--------------------------------
 
 add_compile_options("$<$<CONFIG:DEBUG>:-DDEBUG>") # Define DEBUG in Debug builds
+
+# Takes more time to process but decreases Vertex array size.
+# There can still be position duplicates as they would have different texture coordinates
+option(DECAY_BSP_NO_DUPLICATES "Avoid duplicate vertices when parsing BSP" ON)
+if(DECAY_BSP_NO_DUPLICATES)
+    add_compile_definitions("BSP_NO_DUPLICATES")
+endif()
+
+# Still processes faces to triangles so they must be processed back (not slow).
+option(DECAY_OBJ_POLYGONS "Exporting as OBJ uses polygons instead of triangles" ON)
+if(DECAY_OBJ_POLYGONS)
+    add_compile_definitions("BSP_OBJ_POLYGONS")
+endif()
 
 #--------------------------------
 # Compiler configuration

--- a/src/Decay/Bsp/BspTree.cpp
+++ b/src/Decay/Bsp/BspTree.cpp
@@ -178,16 +178,22 @@ namespace Decay::Bsp
         //for(auto& model : Models)
         for(std::size_t mi = 0; mi < Models.size(); mi++)
         {
-            auto& model = Models[mi];
+            out << std::endl;
 
             out << "o Model_" << mi << std::endl;
 
-            for(auto& kvp : model->Indices)
+            for(auto& kvp : Models[mi]->Indices)
             {
+                out << std::endl;
+
                 out << "g texture_" << Textures[kvp.first].Name << std::endl;
                 out << "usemtl texture_" << Textures[kvp.first].Name << std::endl;
 
                 auto& indices = kvp.second;
+
+#ifdef BSP_OBJ_POLYGONS
+                bool prevPolygon = false;
+#endif
 
                 assert(indices.size() % 3 == 0);
                 for(std::size_t ii = 0; ii < indices.size(); ii += 3)
@@ -201,8 +207,41 @@ namespace Decay::Bsp
                     assert(i1 <= Vertices.size());
                     assert(i2 <= Vertices.size());
 
-                    //THINK Convert indices back to plygon face
+#ifdef BSP_OBJ_POLYGONS
+                    if(prevPolygon)
+                        out  << ' ' << i2 << '/' << i2;
+                    else
+                        out << "f " << i0 << '/' << i0 << ' ' << i1 << '/' << i1 << ' ' << i2 << '/' << i2;
+#else
                     out << "f " << i0 << '/' << i0 << ' ' << i1 << '/' << i1 << ' ' << i2 << '/' << i2 << std::endl;
+#endif
+
+#ifdef BSP_OBJ_POLYGONS
+                    // Is there another triangle?
+                    if(ii + 3 < indices.size())
+                    {
+                        uint16_t i3 = indices[ii + 0 + 3] + 1;
+                        uint16_t i4 = indices[ii + 1 + 3] + 1;
+                        uint16_t i5 = indices[ii + 2 + 3] + 1;
+
+                        // Format of output from polygon->triangles function
+                        // [ii + 0] is same
+                        // old [ii + 2] -> new [ii + 1]
+                        // Only new index is new [ii + 2]
+                        prevPolygon = (i0 == i3 && i2 == i4);
+
+                        // Next triangle is not from same polygon
+                        if(!prevPolygon)
+                            out << std::endl;
+                    }
+                    else
+                    {
+                        //prevPolygon = false; // Not needed as there are no more indices
+                        out << std::endl;
+                    }
+#else
+                    out << std::endl;
+#endif
                 }
             }
 

--- a/src/Decay/Bsp/BspTree.cpp
+++ b/src/Decay/Bsp/BspTree.cpp
@@ -169,7 +169,7 @@ namespace Decay::Bsp
         for(const auto& vec : Vertices)
         {
             out << "v " << -vec.Position.x << ' ' << vec.Position.z << ' ' << vec.Position.y << std::endl;
-            out << "vt " << 1-vec.UV.x << ' ' << vec.UV.y << std::endl;
+            out << "vt " << vec.UV.x << ' ' << 1-vec.UV.y << std::endl;
         }
 
         out.flush();

--- a/src/Decay/Bsp/BspTree.hpp
+++ b/src/Decay/Bsp/BspTree.hpp
@@ -8,6 +8,10 @@
 // Takes more time to process but decreases Vertex size.
 #define BSP_NO_DUPLICATES
 
+// Enable to export OBJ not as triangles but as polygons.
+// Still processes faces to triangles so they must be processed back (not slow).
+#define BSP_OBJ_POLYGONS
+
 namespace Decay::Bsp
 {
     class BspTree

--- a/src/Decay/Bsp/BspTree.hpp
+++ b/src/Decay/Bsp/BspTree.hpp
@@ -4,14 +4,6 @@
 
 #include "BspFile.hpp"
 
-// Enabling this adds vertices without duplicates.
-// Takes more time to process but decreases Vertex size.
-#define BSP_NO_DUPLICATES
-
-// Enable to export OBJ not as triangles but as polygons.
-// Still processes faces to triangles so they must be processed back (not slow).
-#define BSP_OBJ_POLYGONS
-
 namespace Decay::Bsp
 {
     class BspTree


### PR DESCRIPTION
Based on [Wavefront .obj file format](https://en.wikipedia.org/wiki/Wavefront_.obj_file#Vertex_indices), faces can have more than 3 vertices.
All BSP faces are convex (otherwise GoldSrc would have problem with them).

Marke as `need testing` as it needs to be verified in 3D viewer (and I currently have none).